### PR TITLE
Replace SFU sync with a remembered WebRTC peer mesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Built as a React Router SPA (client-side rendering with prerendered pages), depl
 Connect your own devices to control playback across them — for example, place a tablet below the TV showing subtitles and control it from your phone.
 
 - Each device has a permanent pairing code. Tap **Start pairing** to show your code and QR, then scan it (or type the code) from your other device to connect them.
-- Play, pause, seek and speed on one device control the others; the device whose code you connected to is the host and its playback is authoritative.
-- Subtitles transfer directly between devices over an encrypted peer-to-peer WebRTC data channel. **No subtitle content is ever stored on or served by the server** — a hibernatable Durable Object only relays temporary SDP/ICE signaling. Pairing is direct-only, so both devices should be on a network that permits device-to-device traffic.
+- Up to five devices form a remembered peer-to-peer mesh. Any device can display subtitles or control playback, while an internal coordinator is elected automatically.
+- Subtitles transfer directly between devices over encrypted WebRTC data channels. **No subtitle content or group membership is stored on or served by the server** — a hibernatable Durable Object only relays bounded SDP/ICE signaling between currently online members. Pairing is direct-only, so devices must be on networks that permit direct connectivity.
 - The connection is remembered: reopening the app reconnects your devices automatically.
+- The group code is a bearer invitation: anyone with it can join as an equal member. Use **Create new group** to rotate the code and revoke the old invitation.
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Connect your own devices to control playback across them — for example, place 
 
 - Each device has a permanent pairing code. Tap **Start pairing** to show your code and QR, then scan it (or type the code) from your other device to connect them.
 - Play, pause, seek and speed on one device control the others; the device whose code you connected to is the host and its playback is authoritative.
-- Subtitles transfer directly between devices over an encrypted WebRTC data channel (Cloudflare Realtime SFU). **No subtitle content is ever stored on or served by the server** — a hibernatable Durable Object only coordinates presence and opaque WebRTC session IDs. Both devices need to be online.
+- Subtitles transfer directly between devices over an encrypted peer-to-peer WebRTC data channel. **No subtitle content is ever stored on or served by the server** — a hibernatable Durable Object only relays temporary SDP/ICE signaling. Pairing is direct-only, so both devices should be on a network that permits device-to-device traffic.
 - The connection is remembered: reopening the app reconnects your devices automatically.
 
 ## Stack
@@ -20,7 +20,7 @@ Connect your own devices to control playback across them — for example, place 
 - MobX 7 + mobx-react-lite 5 for player state
 - Tailwind CSS 4
 - IndexedDB (via `idb`) for subtitle storage
-- Cloudflare Workers and hibernatable Durable Objects via Wrangler 4, Cloudflare Realtime SFU for WebRTC signaling/relay
+- Cloudflare Workers and hibernatable Durable Objects via Wrangler 4, with STUN-assisted direct WebRTC connectivity
 
 ## Development
 
@@ -33,10 +33,6 @@ The API Worker (sync signaling) does not run under `pnpm dev`. To test the sync 
 
 ```sh
 pnpm build
-# create a Realtime SFU app in the Cloudflare dashboard, then:
-#   - set APP_ID in wrangler.json vars
-#   - run: npx wrangler secret put APP_TOKEN
-#   - or put both in .dev.vars (local only)
 npx wrangler dev
 ```
 

--- a/app/routes/play.tsx
+++ b/app/routes/play.tsx
@@ -69,15 +69,15 @@ const Play = observer(() => {
 		}
 	}, [])
 
-	// When becoming the host while a file is already loaded (e.g. the user
-	// started hosting from the sync page), announce the current file.
+	// When becoming the internal coordinator with a file already loaded,
+	// announce it to the rest of the group.
 	useEffect(() => {
-		if (syncStore.role === 'host') {
+		if (syncStore.isCoordinator) {
 			void syncStore.onFileLoaded()
 		}
-	}, [syncStore.role])
+	}, [syncStore.isCoordinator])
 
-	// When the host announces a file and we don't have one loaded, open it.
+	// When the group coordinator announces a file, open it if needed.
 	useEffect(() => {
 		const pending = syncStore.pendingNowPlaying
 		if (!pending) return

--- a/app/routes/sync.tsx
+++ b/app/routes/sync.tsx
@@ -32,7 +32,7 @@ const SyncPage = observer(() => {
 					codeParam
 						.toUpperCase()
 						.replace(/[^A-Z0-9]/g, '')
-						.slice(0, 10),
+						.slice(0, 20),
 				)
 				await join(codeParam)
 			} else {
@@ -52,7 +52,7 @@ const SyncPage = observer(() => {
 
 	async function join(codeOverride?: string) {
 		const code = (codeOverride ?? codeInput).trim()
-		if (code.length !== 10) return
+		if (code.length !== 20) return
 		setBusy(true)
 		try {
 			await syncStore.joinGroup(code)
@@ -258,7 +258,7 @@ const SyncPage = observer(() => {
 									e.target.value
 										.toUpperCase()
 										.replace(/[^A-Z0-9]/g, '')
-										.slice(0, 10),
+										.slice(0, 20),
 								)
 							}
 							placeholder="Enter the code shown on the other device"
@@ -270,7 +270,7 @@ const SyncPage = observer(() => {
 						/>
 						<Button
 							onClick={() => void join()}
-							disabled={busy || connecting || codeInput.trim().length !== 10}
+							disabled={busy || connecting || codeInput.trim().length !== 20}
 						>
 							{busy || connecting ? 'Connecting…' : 'Connect'}
 						</Button>

--- a/app/routes/sync.tsx
+++ b/app/routes/sync.tsx
@@ -27,6 +27,7 @@ const SyncPage = observer(() => {
 		const codeParam = new URL(location.href).searchParams.get('code')
 		void (async () => {
 			await syncStore.init()
+			if (codeParam) window.history.replaceState(null, '', location.pathname)
 			if (codeParam && codeParam.toUpperCase() !== syncStore.myGroupCode) {
 				setCodeInput(
 					codeParam
@@ -43,9 +44,7 @@ const SyncPage = observer(() => {
 
 	const connecting = syncStore.connectionState === 'connecting'
 	const connected = syncStore.connectionState === 'connected'
-	const isOwner = syncStore.role === 'host'
-	const isMember = syncStore.role === 'follower'
-	const active = isOwner || isMember
+	const active = syncStore.role === 'peer'
 	const qrValue = syncStore.roomCode
 		? `${location.origin}/sync?code=${syncStore.roomCode}`
 		: ''
@@ -82,8 +81,8 @@ const SyncPage = observer(() => {
 				<p className="max-w-prose text-sm text-gray-600">
 					Connect your own devices. Place a tablet below the TV and control it
 					from your phone. Play, pause and seek on one device control the
-					others. Subtitles transfer directly between devices. Nothing is stored
-					on a server, and both devices need to be online.
+					others. Up to five devices form a direct mesh, and no device needs to
+					stay in a special host role. Nothing is stored on the signaling server.
 				</p>
 			</Block>
 
@@ -135,9 +134,7 @@ const SyncPage = observer(() => {
 						{syncStore.isRestoring || connecting
 							? 'Connecting…'
 							: connected
-								? isOwner
-									? 'Sharing this device'
-									: `Connected to device ${syncStore.roomCode ?? ''}`
+								? `Connected to group ${syncStore.roomCode ?? ''}`
 								: syncStore.connectionState === 'error'
 									? 'Not connected'
 									: 'Not sharing'}
@@ -151,13 +148,13 @@ const SyncPage = observer(() => {
 			</Block>
 
 			{/* ---------------------------------------------------------- */}
-			{/* Owner: code + QR + members                                   */}
+			{/* Active group: code + QR + members                            */}
 			{/* ---------------------------------------------------------- */}
-			{isOwner && (
+			{active && (
 				<>
 					<Block className="px-4">
 						<div className="text-center">
-							<p className="text-sm text-gray-600">This device's code</p>
+							<p className="text-sm text-gray-600">Your group code</p>
 							<p className="font-mono text-4xl font-bold tracking-[0.4em]">
 								{syncStore.roomCode}
 							</p>
@@ -165,7 +162,7 @@ const SyncPage = observer(() => {
 								<QrCode value={qrValue} size={176} />
 							</div>
 							<p className="mt-2 text-xs text-gray-500">
-								Scan this from your other device to connect it.
+								Scan this once on another device to add it to this group.
 							</p>
 							<Button
 								className="mt-3"
@@ -175,36 +172,21 @@ const SyncPage = observer(() => {
 							>
 								Copy link
 							</Button>
-						</div>
-					</Block>
-
-					<MembersList />
-				</>
-			)}
-
-			{/* ---------------------------------------------------------- */}
-			{/* Member: group info + leave                                   */}
-			{/* ---------------------------------------------------------- */}
-			{isMember && (
-				<>
-					<Block className="px-4">
-						<div className="text-center">
-							<p className="text-sm text-gray-600">
-								Connected to device{' '}
-								<span className="font-mono font-semibold">
-									{syncStore.roomCode}
-								</span>
-							</p>
-							<p className="mt-1 text-xs text-gray-500">
-								You can control it from here.
-							</p>
 							<Button
-								className="mt-3"
+								className="mt-3 ml-2"
 								onClick={() => {
-									void syncStore.leaveGroup()
+									void (syncStore.joinedGroupCode
+										? syncStore.leaveGroup()
+										: syncStore.stopSharing())
 								}}
 							>
 								Disconnect
+							</Button>
+							<Button
+								className="mt-3 ml-2"
+								onClick={() => void syncStore.createNewGroup()}
+							>
+								Create new group
 							</Button>
 						</div>
 					</Block>
@@ -263,7 +245,7 @@ const SyncPage = observer(() => {
 							}
 							placeholder="Enter the code shown on the other device"
 							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-center font-mono text-xl tracking-widest"
-							maxLength={6}
+							maxLength={20}
 							autoCapitalize="characters"
 							autoCorrect="off"
 							spellCheck={false}
@@ -299,7 +281,7 @@ const MembersList = observer(() => {
 					<ListItem
 						key={peer.sessionId}
 						title={peer.name}
-						after={peer.isHost ? 'Host' : 'Device'}
+						after="Device"
 						footer={
 							<span
 								className={cn(

--- a/app/shared/sync.ts
+++ b/app/shared/sync.ts
@@ -13,9 +13,9 @@ import {
 } from './utils'
 
 /**
- * Multi-device sync via WebRTC data channels brokered by Cloudflare
- * Realtime SFU (signaling proxied through /api/sync on the Worker). Subtitle content never touches the server: it travels
- * only over the data channel, device to device.
+ * Multi-device sync over direct, bidirectional WebRTC data channels.
+ * A hibernatable Durable Object relays only temporary SDP/ICE signaling;
+ * No relay is configured: peers must establish a direct connection.
  *
  * Device pairing: every device owns a persistent pairing code and can
  * either share its own code (QR/code on screen) or connect to another
@@ -23,10 +23,7 @@ import {
  * its clock is authoritative, and the connected device controls it
  * with play/pause/seek/speed commands.
  *
- * Topology (hub and spoke, full duplex per pair):
- *   - Every device publishes its own "subtitles" data channel.
- *   - The host pulls each connected device's channel (device -> host).
- *   - Each connected device pulls the host's channel (host -> devices).
+ * Topology is hub-and-spoke, with one full-duplex data channel per pair.
  */
 
 const API = '/api/sync'
@@ -35,6 +32,10 @@ const CHUNK_SIZE = 32 * 1024
 const BROADCAST_INTERVAL_MS = 100
 const PING_INTERVAL_MS = 5000
 const CONNECT_TIMEOUT_MS = 15000
+const MAX_PRESENCE_RECONNECT_ATTEMPTS = 6
+const MAX_OUTBOUND_QUEUE = 128
+const MAX_CONCURRENT_TRANSFERS = 4
+const MAX_TRANSFER_CHUNKS = 1024
 const ROOM_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
 
 export type SyncRole = 'none' | 'host' | 'follower'
@@ -53,28 +54,25 @@ export interface ReceivedFile {
 	name: string
 }
 
-interface PresenceSnapshot {
-	type: 'snapshot'
-	hostSessionId: string
-	peers: { sessionId: string; name: string; isHost: boolean }[]
-}
+type SignalMessage =
+	| { type: 'peers'; peers: { id: string; name: string; isHost: boolean }[] }
+	| {
+			type: 'offer' | 'answer'
+			from: string
+			generation: string
+			sdp: RTCSessionDescriptionInit
+	  }
+	| {
+			type: 'ice'
+			from: string
+			generation: string
+			candidates: RTCIceCandidateInit[]
+	  }
 
-const isPresenceSnapshot = (value: unknown): value is PresenceSnapshot => {
-	if (!value || typeof value !== 'object') return false
-	const message = value as Partial<PresenceSnapshot>
-	return (
-		message.type === 'snapshot' &&
-		typeof message.hostSessionId === 'string' &&
-		Array.isArray(message.peers) &&
-		message.peers.every(
-			(peer) =>
-				peer &&
-				typeof peer === 'object' &&
-				typeof peer.sessionId === 'string' &&
-				typeof peer.name === 'string' &&
-				typeof peer.isHost === 'boolean',
-		)
-	)
+interface PeerTransport {
+	pc: RTCPeerConnection
+	generation: string
+	pendingIce: RTCIceCandidateInit[]
 }
 
 export type SyncMessage =
@@ -106,7 +104,7 @@ export type SyncMessage =
 	| { type: 'pong'; sentAt: number }
 
 const makeRoomCode = (): string => {
-	const chars = new Uint8Array(10)
+	const chars = new Uint8Array(20)
 	crypto.getRandomValues(chars)
 	let code = ''
 	for (const c of chars) {
@@ -156,10 +154,14 @@ class SyncStore {
 
 	/** non-observable WebRTC state */
 	pc: RTCPeerConnection | null = null
+	peerTransports = new Map<string, PeerTransport>()
+	earlyIce = new Map<
+		string,
+		{ generation: string; candidates: RTCIceCandidateInit[] }
+	>()
 	outboundDc: RTCDataChannel | null = null
 	inboundDcs: Map<string, RTCDataChannel> = new Map()
 	outboundQueue: string[] = []
-	pulledPeers = new Set<string>()
 	presenceSocket: WebSocket | null = null
 	presenceReconnectTimer: number | null = null
 	presenceReconnectAttempts = 0
@@ -185,10 +187,11 @@ class SyncStore {
 			this,
 			{
 				pc: false,
+				peerTransports: false,
+				earlyIce: false,
 				outboundDc: false,
 				inboundDcs: false,
 				outboundQueue: false,
-				pulledPeers: false,
 				presenceSocket: false,
 				presenceReconnectTimer: false,
 				presenceReconnectAttempts: false,
@@ -238,7 +241,7 @@ class SyncStore {
 	}
 
 	private async ensureMyGroup(): Promise<string> {
-		if (!this.myGroupCode || this.myGroupCode.length !== 10) {
+		if (!this.myGroupCode || this.myGroupCode.length !== 20) {
 			this.myGroupCode = makeRoomCode()
 			await setSetting('myGroupCode', this.myGroupCode)
 		}
@@ -312,9 +315,15 @@ class SyncStore {
 
 	send(msg: SyncMessage) {
 		const raw = JSON.stringify(msg)
-		if (this.outboundDc && this.outboundDc.readyState === 'open') {
+		if (this.role === 'host') {
+			for (const dc of this.inboundDcs.values()) {
+				if (dc.readyState === 'open') dc.send(raw)
+			}
+		} else if (this.outboundDc && this.outboundDc.readyState === 'open') {
 			this.outboundDc.send(raw)
 		} else {
+			if (this.outboundQueue.length >= MAX_OUTBOUND_QUEUE)
+				this.outboundQueue.shift()
 			this.outboundQueue.push(raw)
 		}
 	}
@@ -329,16 +338,7 @@ class SyncStore {
 		this.role = 'host'
 
 		try {
-			const { sessionId } = await sfu('/sessions/new', { method: 'POST' })
-			this.sessionId = sessionId
-
-			const pc = makePeerConnection()
-			this.pc = pc
-			this._monitorConnection(pc)
-
-			await establishTransport(pc, sessionId, true)
-			await this.publishChannel(pc, sessionId)
-
+			this.sessionId = makeConnectionId()
 			this.roomCode = keepCode
 			this._startConnectTimeout()
 			await this._connectPresence('host')
@@ -359,44 +359,33 @@ class SyncStore {
 		this.role = 'follower'
 
 		try {
-			const room = (await (
-				await fetch(
-					`${API}?action=lookup-room&code=${encodeURIComponent(code)}`,
-				)
-			).json()) as { hostSessionId?: string; error?: string }
-			if (!room.hostSessionId) {
-				throw new Error(room.error ?? 'Group not found')
-			}
-			const hostSessionId = room.hostSessionId as string
 			this.roomCode = code.toUpperCase()
-
-			const { sessionId } = await sfu('/sessions/new', { method: 'POST' })
-			this.sessionId = sessionId
-
-			const pc = makePeerConnection()
-			this.pc = pc
-			this._monitorConnection(pc)
-
-			await establishTransport(pc, sessionId, false)
-			await this.publishChannel(pc, sessionId)
+			this.sessionId = makeConnectionId()
 			this._startPing()
-
 			this._startConnectTimeout()
-			const hostDc = await this.pullChannel(pc, hostSessionId)
-			this.inboundDcs.set(hostSessionId, hostDc)
-			this._attachInboundChannel(hostDc)
-
-			this.connectionState = 'connected'
-			this._clearConnectTimeout()
-
-			this.send({ type: 'join', deviceName: this.deviceName })
 			await this._connectPresence('follower')
+			await this._waitForPeerConnection()
 		} catch (err) {
 			this._fail(
 				err,
 				'Could not reach this group. Make sure the owner is sharing and try again.',
 			)
 		}
+	}
+
+	private _waitForPeerConnection(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const started = Date.now()
+			const check = window.setInterval(() => {
+				if (this.connectionState === 'connected') {
+					window.clearInterval(check)
+					resolve()
+				} else if (Date.now() - started >= CONNECT_TIMEOUT_MS) {
+					window.clearInterval(check)
+					reject(new Error('Connection timed out'))
+				}
+			}, 100)
+		})
 	}
 
 	// ------------------------------------------------------------------
@@ -513,7 +502,32 @@ class SyncStore {
 	// Incoming messages
 	// ------------------------------------------------------------------
 
-	private _handleMessage(msg: SyncMessage) {
+	private _handleMessage(value: unknown) {
+		if (!value || typeof value !== 'object' || Array.isArray(value)) return
+		const msg = value as SyncMessage
+		const allowed =
+			this.role === 'host'
+				? new Set([
+						'cmd-play',
+						'cmd-pause',
+						'cmd-seek',
+						'cmd-speed',
+						'join',
+						'leave',
+						'request-file',
+						'ping',
+						'pong',
+					])
+				: new Set([
+						'state-clock',
+						'now-playing',
+						'file-list',
+						'file-chunk',
+						'file-deleted',
+						'ping',
+						'pong',
+					])
+		if (!allowed.has(msg.type)) return
 		switch (msg.type) {
 			case 'state-clock':
 				this._applyClockState(msg)
@@ -631,8 +645,24 @@ class SyncStore {
 	}
 
 	private _handleFileChunk(msg: Extract<SyncMessage, { type: 'file-chunk' }>) {
+		if (
+			typeof msg.transferId !== 'string' ||
+			msg.transferId.length > 128 ||
+			typeof msg.fileName !== 'string' ||
+			msg.fileName.length > 256 ||
+			!Number.isInteger(msg.totalChunks) ||
+			msg.totalChunks < 1 ||
+			msg.totalChunks > MAX_TRANSFER_CHUNKS ||
+			!Number.isInteger(msg.chunkIndex) ||
+			msg.chunkIndex < 0 ||
+			msg.chunkIndex >= msg.totalChunks ||
+			typeof msg.data !== 'string' ||
+			msg.data.length > CHUNK_SIZE
+		)
+			return
 		let buffer = this.receiveBuffers.get(msg.transferId)
 		if (!buffer) {
+			if (this.receiveBuffers.size >= MAX_CONCURRENT_TRANSFERS) return
 			buffer = {
 				fileName: msg.fileName,
 				total: msg.totalChunks,
@@ -644,6 +674,8 @@ class SyncStore {
 			}
 			this.receiveBuffers.set(msg.transferId, buffer)
 		}
+		if (buffer.total !== msg.totalChunks || buffer.fileName !== msg.fileName)
+			return
 		buffer.chunks[msg.chunkIndex] = msg.data
 		this._updateTransfers()
 
@@ -701,57 +733,41 @@ class SyncStore {
 	// WebRTC plumbing
 	// ------------------------------------------------------------------
 
-	private async publishChannel(pc: RTCPeerConnection, sessionId: string) {
-		const response = await sfu(`/sessions/${sessionId}/datachannels/new`, {
-			method: 'POST',
-			body: JSON.stringify({
-				dataChannels: [{ location: 'local', dataChannelName: DC_NAME }],
-			}),
-		})
-		const dc = pc.createDataChannel(DC_NAME, {
-			negotiated: true,
-			id: response.dataChannels[0].id,
-		})
-		this.outboundDc = dc
-		dc.onopen = () => {
-			while (this.outboundQueue.length > 0) {
-				const raw = this.outboundQueue.shift()
-				if (raw !== undefined) dc.send(raw)
-			}
-		}
-	}
-
-	private async pullChannel(pc: RTCPeerConnection, publisherSessionId: string) {
-		const response = await sfu(`/sessions/${this.sessionId}/datachannels/new`, {
-			method: 'POST',
-			body: JSON.stringify({
-				dataChannels: [
-					{
-						location: 'remote',
-						sessionId: publisherSessionId,
-						dataChannelName: DC_NAME,
-					},
-				],
-			}),
-		})
-		const dc = pc.createDataChannel(DC_NAME, {
-			negotiated: true,
-			id: response.dataChannels[0].id,
-		})
-		return dc
-	}
-
-	private _monitorConnection(pc: RTCPeerConnection) {
+	private _monitorConnection(pc: RTCPeerConnection, peerId: string) {
 		pc.onconnectionstatechange = () => {
+			if (pc.connectionState === 'connected') {
+				this.connectionState = 'connected'
+				this.presenceReconnectAttempts = 0
+				this._clearConnectTimeout()
+				if (this.role === 'follower')
+					this._sendSignal({
+						type: 'ready',
+						to: peerId,
+						generation:
+							this.peerTransports.get(peerId)?.generation ??
+							makeConnectionId(),
+					})
+			}
 			if (pc.connectionState === 'failed' || pc.connectionState === 'closed') {
-				if (this.pc === pc && this.connectionState === 'connected') {
-					this.connectionState = 'disconnected'
+				const transport = this.peerTransports.get(peerId)
+				if (transport?.pc === pc) this.peerTransports.delete(peerId)
+				this.roomPeers = this.roomPeers.map((peer) =>
+					peer.sessionId === peerId ? { ...peer, connected: false } : peer,
+				)
+				if (
+					this.role === 'follower' &&
+					!this.presenceIntentionalClose &&
+					this.roomCode
+				) {
+					this.connectionState = 'connecting'
+					this._startConnectTimeout()
+					this._schedulePresenceReconnect('follower')
 				}
 			}
 		}
 	}
 
-	private _attachInboundChannel(dc: RTCDataChannel) {
+	private _attachDataChannel(dc: RTCDataChannel, peerId: string) {
 		dc.onmessage = (event) => {
 			try {
 				this._handleMessage(JSON.parse(event.data))
@@ -759,15 +775,127 @@ class SyncStore {
 				console.warn('Ignoring malformed sync message', err)
 			}
 		}
-		dc.onclose = () => {
-			for (const [key, channel] of this.inboundDcs) {
-				if (channel === dc) {
-					this.inboundDcs.delete(key)
-					this.roomPeers = this.roomPeers.map((peer) =>
-						peer.sessionId === key ? { ...peer, connected: false } : peer,
-					)
-				}
+		dc.onopen = () => {
+			if (this.role === 'follower') this.outboundDc = dc
+			else this.inboundDcs.set(peerId, dc)
+			this.roomPeers = this.roomPeers.map((peer) =>
+				peer.sessionId === peerId ? { ...peer, connected: true } : peer,
+			)
+			while (this.outboundQueue.length > 0) {
+				const raw = this.outboundQueue.shift()
+				if (raw !== undefined) dc.send(raw)
 			}
+			if (this.role === 'follower')
+				this.send({ type: 'join', deviceName: this.deviceName })
+			else void this._handlePeerJoin()
+		}
+		dc.onclose = () => {
+			this.inboundDcs.delete(peerId)
+			if (this.outboundDc === dc) this.outboundDc = null
+		}
+	}
+
+	private _newPeer(peerId: string, generation: string): PeerTransport {
+		this.peerTransports.get(peerId)?.pc.close()
+		const pc = new RTCPeerConnection({
+			iceServers: [{ urls: 'stun:stun.cloudflare.com:3478' }],
+			iceTransportPolicy: 'all',
+			bundlePolicy: 'max-bundle',
+		})
+		const transport: PeerTransport = { pc, generation, pendingIce: [] }
+		const early = this.earlyIce.get(peerId)
+		if (early?.generation === generation)
+			transport.pendingIce.push(...early.candidates)
+		this.earlyIce.delete(peerId)
+		this.peerTransports.set(peerId, transport)
+		if (this.role === 'follower') this.pc = pc
+		this._monitorConnection(pc, peerId)
+		pc.onicecandidate = (event) => {
+			if (event.candidate)
+				this._sendSignal({
+					type: 'ice',
+					to: peerId,
+					generation,
+					candidates: [event.candidate.toJSON()],
+				})
+		}
+		return transport
+	}
+
+	private async _offerPeer(peerId: string) {
+		const generation = makeConnectionId()
+		const transport = this._newPeer(peerId, generation)
+		const dc = transport.pc.createDataChannel(DC_NAME)
+		this._attachDataChannel(dc, peerId)
+		await transport.pc.setLocalDescription(await transport.pc.createOffer())
+		this._sendSignal({
+			type: 'offer',
+			to: peerId,
+			generation,
+			sdp: transport.pc.localDescription,
+		})
+	}
+
+	private async _handleSignal(message: SignalMessage) {
+		if (message.type === 'peers') {
+			const signaled = message.peers
+				.filter((peer) => peer.id !== this.sessionId)
+				.map((peer) => ({
+					sessionId: peer.id,
+					name: peer.name,
+					isHost: peer.isHost,
+					connected:
+						this.inboundDcs.has(peer.id) ||
+						(peer.isHost && this.outboundDc?.readyState === 'open'),
+				}))
+			const signaledIds = new Set(signaled.map((peer) => peer.sessionId))
+			this.roomPeers = [
+				...signaled,
+				...this.roomPeers.filter(
+					(peer) => peer.connected && !signaledIds.has(peer.sessionId),
+				),
+			]
+			if (this.role === 'host')
+				for (const peer of message.peers)
+					if (!peer.isHost && !this.peerTransports.has(peer.id))
+						void this._offerPeer(peer.id)
+			return
+		}
+		if (message.type === 'offer' && this.role === 'follower') {
+			const transport = this._newPeer(message.from, message.generation)
+			transport.pc.ondatachannel = (event) =>
+				this._attachDataChannel(event.channel, message.from)
+			await transport.pc.setRemoteDescription(message.sdp)
+			for (const ice of transport.pendingIce.splice(0))
+				await transport.pc.addIceCandidate(ice)
+			await transport.pc.setLocalDescription(await transport.pc.createAnswer())
+			this._sendSignal({
+				type: 'answer',
+				to: message.from,
+				generation: message.generation,
+				sdp: transport.pc.localDescription,
+			})
+			return
+		}
+		const transport = this.peerTransports.get(message.from)
+		if (!transport || transport.generation !== message.generation) {
+			if (message.type === 'ice')
+				this.earlyIce.set(message.from, {
+					generation: message.generation,
+					candidates: message.candidates,
+				})
+			return
+		}
+		if (message.type === 'answer' && this.role === 'host') {
+			await transport.pc.setRemoteDescription(message.sdp)
+			for (const ice of transport.pendingIce.splice(0))
+				await transport.pc.addIceCandidate(ice)
+		} else if (message.type === 'ice') {
+			if (!transport.pc.remoteDescription)
+				transport.pendingIce.push(...message.candidates)
+			else
+				for (const ice of message.candidates)
+					await transport.pc.addIceCandidate(ice)
 		}
 	}
 
@@ -785,7 +913,7 @@ class SyncStore {
 		url.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
 		url.searchParams.set('code', this.roomCode)
 		url.searchParams.set('role', role)
-		url.searchParams.set('sessionId', this.sessionId)
+		url.searchParams.set('id', this.sessionId)
 		url.searchParams.set('name', this.deviceName.slice(0, 64))
 		const protocols = ['subtitle-sync']
 		if (role === 'host') {
@@ -807,11 +935,12 @@ class SyncStore {
 			}
 			socket.onmessage = (event) => {
 				try {
-					const message: unknown = JSON.parse(String(event.data))
-					if (!isPresenceSnapshot(message)) return
-					this._applyPresenceSnapshot(message)
-					this.presenceReconnectAttempts = 0
-					if (!settled) {
+					const message = JSON.parse(String(event.data)) as SignalMessage
+					void this._handleSignal(message).catch((err) =>
+						console.warn('Signal failed', err),
+					)
+					if (role === 'host') this.presenceReconnectAttempts = 0
+					if (!settled && message.type === 'peers') {
 						settled = true
 						resolve()
 					}
@@ -828,6 +957,7 @@ class SyncStore {
 					isCurrentSocket &&
 					!this.presenceIntentionalClose &&
 					this.role === role &&
+					(role === 'host' || this.connectionState !== 'connected') &&
 					this.roomCode
 				) {
 					this._schedulePresenceReconnect(role)
@@ -836,28 +966,23 @@ class SyncStore {
 		})
 	}
 
-	private _applyPresenceSnapshot(room: PresenceSnapshot) {
-		this.roomPeers = room.peers
-			.filter((peer) => peer.sessionId !== this.sessionId)
-			.map((peer) => ({
-				...peer,
-				connected: this.inboundDcs.has(peer.sessionId),
-			}))
-		if (this.role !== 'host' || !this.pc) return
-		for (const peer of room.peers) {
-			if (
-				peer.sessionId !== this.sessionId &&
-				!this.pulledPeers.has(peer.sessionId)
-			) {
-				this.pulledPeers.add(peer.sessionId)
-				void this._pullPeerChannel(peer.sessionId)
-			}
-		}
+	private _sendSignal(message: Record<string, unknown>) {
+		if (this.presenceSocket?.readyState === WebSocket.OPEN)
+			this.presenceSocket.send(JSON.stringify(message))
 	}
 
 	private _schedulePresenceReconnect(role: Exclude<SyncRole, 'none'>) {
 		if (this.presenceReconnectTimer !== null) return
-		const attempt = Math.min(this.presenceReconnectAttempts++, 5)
+		if (
+			this.presenceReconnectAttempts >= MAX_PRESENCE_RECONNECT_ATTEMPTS
+		) {
+			if (role === 'follower' && this.connectionState !== 'connected') {
+				this.connectionState = 'error'
+				this.error = 'Could not reconnect directly to the other device'
+			}
+			return
+		}
+		const attempt = this.presenceReconnectAttempts++
 		const delay = Math.min(30_000, 1000 * 2 ** attempt) + Math.random() * 500
 		this.presenceReconnectTimer = window.setTimeout(() => {
 			this.presenceReconnectTimer = null
@@ -873,25 +998,6 @@ class SyncStore {
 		}
 		this.presenceSocket?.close(1000, 'Leaving room')
 		this.presenceSocket = null
-	}
-
-	private async _pullPeerChannel(sessionId: string) {
-		if (!this.pc || !this.sessionId) return
-		try {
-			const dc = await this.pullChannel(this.pc, sessionId)
-			this.inboundDcs.set(sessionId, dc)
-			this._attachInboundChannel(dc)
-			this.roomPeers = this.roomPeers.map((peer) =>
-				peer.sessionId === sessionId ? { ...peer, connected: true } : peer,
-			)
-			// The newly joined device's own channel may have been open before
-			// we pulled it, so its initial 'join' message could have been
-			// dropped (no subscribers yet). Push our current state to it.
-			await this._handlePeerJoin()
-		} catch (err) {
-			console.warn('Failed to pull peer channel', err)
-			this.pulledPeers.delete(sessionId)
-		}
 	}
 
 	// ------------------------------------------------------------------
@@ -971,7 +1077,9 @@ class SyncStore {
 		this.outboundDc?.close()
 		this.outboundDc = null
 		this.outboundQueue.length = 0
-		this.pulledPeers.clear()
+		for (const transport of this.peerTransports.values()) transport.pc.close()
+		this.peerTransports.clear()
+		this.earlyIce.clear()
 		this.pc?.close()
 		this.pc = null
 	}
@@ -993,62 +1101,13 @@ class SyncStore {
 export const syncStore = new SyncStore()
 
 // ----------------------------------------------------------------------
-// SFU helpers
+// Direct WebRTC helpers
 // ----------------------------------------------------------------------
 
-const sfu = async (path: string, init?: RequestInit): Promise<any> => {
-	const response = await fetch(`${API}/sfu${path}`, init)
-	if (!response.ok) {
-		throw new Error(`SFU request failed (${response.status})`)
-	}
-	return response.json()
-}
-
-const makePeerConnection = (): RTCPeerConnection =>
-	new RTCPeerConnection({
-		iceServers: [{ urls: 'stun:stun.cloudflare.com:3478' }],
-		bundlePolicy: 'max-bundle',
-	})
-
-const establishTransport = async (
-	pc: RTCPeerConnection,
-	sessionId: string,
-	makeOffer: boolean,
-) => {
-	let sdp: string | undefined
-	if (makeOffer) {
-		pc.createDataChannel('server-events')
-		sdp = (await pc.createOffer()).sdp
-		await pc.setLocalDescription({ type: 'offer', sdp })
-	}
-
-	const response = await sfu(`/sessions/${sessionId}/datachannels/establish`, {
-		method: 'POST',
-		body: JSON.stringify({
-			dataChannel: {
-				location: 'remote',
-				dataChannelName: 'server-events',
-			},
-			...(sdp !== undefined
-				? { sessionDescription: { type: 'offer', sdp } }
-				: {}),
-		}),
-	})
-
-	if (response.requiresImmediateRenegotiation) {
-		await pc.setRemoteDescription(response.sessionDescription)
-		const answer = await pc.createAnswer()
-		await pc.setLocalDescription(answer)
-		await sfu(`/sessions/${sessionId}/renegotiate`, {
-			method: 'PUT',
-			body: JSON.stringify({
-				sessionDescription: { type: 'answer', sdp: answer.sdp },
-			}),
-		})
-	} else {
-		await pc.setRemoteDescription(response.sessionDescription)
-	}
-}
+const makeConnectionId = () =>
+	[...crypto.getRandomValues(new Uint8Array(16))]
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('')
 
 // ----------------------------------------------------------------------
 // Playback helpers (exported for the controls UI)

--- a/app/shared/sync.ts
+++ b/app/shared/sync.ts
@@ -17,11 +17,9 @@ import {
  * A hibernatable Durable Object relays only temporary SDP/ICE signaling;
  * No relay is configured: peers must establish a direct connection.
  *
- * Device pairing: every device owns a persistent pairing code and can
- * either share its own code (QR/code on screen) or connect to another
- * device's code. The device whose code you connect to is the "host":
- * its clock is authoritative, and the connected device controls it
- * with play/pause/seek/speed commands.
+ * Device pairing creates a remembered group. Every online member connects
+ * directly to every other member, and an internal coordinator is elected
+ * automatically. There are no user-facing host/client roles.
  *
  * Topology is hub-and-spoke, with one full-duplex data channel per pair.
  */
@@ -29,23 +27,22 @@ import {
 const API = '/api/sync'
 const DC_NAME = 'subtitles'
 const CHUNK_SIZE = 32 * 1024
+const MAX_DATA_MESSAGE_CHARS = 64 * 1024
 const BROADCAST_INTERVAL_MS = 100
 const PING_INTERVAL_MS = 5000
 const CONNECT_TIMEOUT_MS = 15000
 const MAX_PRESENCE_RECONNECT_ATTEMPTS = 6
-const MAX_OUTBOUND_QUEUE = 128
 const MAX_CONCURRENT_TRANSFERS = 4
 const MAX_TRANSFER_CHUNKS = 1024
 const ROOM_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
 
-export type SyncRole = 'none' | 'host' | 'follower'
+export type SyncRole = 'none' | 'peer'
 export type ConnectionState =
 	'disconnected' | 'connecting' | 'connected' | 'error'
 
 export interface PeerInfo {
 	sessionId: string
 	name: string
-	isHost: boolean
 	connected: boolean
 }
 
@@ -55,7 +52,7 @@ export interface ReceivedFile {
 }
 
 type SignalMessage =
-	| { type: 'peers'; peers: { id: string; name: string; isHost: boolean }[] }
+	| { type: 'peers'; peers: { id: string; name: string }[] }
 	| {
 			type: 'offer' | 'answer'
 			from: string
@@ -80,6 +77,7 @@ export type SyncMessage =
 	| { type: 'cmd-pause' }
 	| { type: 'cmd-seek'; positionMs: number }
 	| { type: 'cmd-speed'; speed: number }
+	| { type: 'claim-coordinator'; term: number; claimantId: string }
 	| {
 			type: 'state-clock'
 			isPlaying: boolean
@@ -99,7 +97,6 @@ export type SyncMessage =
 			fileName: string
 			data: string
 	  }
-	| { type: 'file-deleted'; fileId: string; fileName: string }
 	| { type: 'ping'; sentAt: number }
 	| { type: 'pong'; sentAt: number }
 
@@ -139,9 +136,11 @@ class SyncStore {
 	error: string | null = null
 	deviceName: string
 	roomPeers: PeerInfo[] = []
+	coordinationClaim: { term: number; claimantId: string } | null = null
 	receivedFiles: ReceivedFile[] = []
 	transfers: { fileName: string; received: number; total: number }[] = []
 	pendingNowPlaying: ReceivedFile | null = null
+	suppressNextFileAnnouncement = false
 
 	/** this device's own persistent group code */
 	myGroupCode: string | null = null
@@ -159,14 +158,11 @@ class SyncStore {
 		string,
 		{ generation: string; candidates: RTCIceCandidateInit[] }
 	>()
-	outboundDc: RTCDataChannel | null = null
 	inboundDcs: Map<string, RTCDataChannel> = new Map()
-	outboundQueue: string[] = []
 	presenceSocket: WebSocket | null = null
 	presenceReconnectTimer: number | null = null
 	presenceReconnectAttempts = 0
 	presenceIntentionalClose = false
-	roomOwnerToken: string | null = null
 	broadcastTimer: number | null = null
 	pingTimer: number | null = null
 	connectTimeout: number | null = null
@@ -180,6 +176,8 @@ class SyncStore {
 		}
 	>()
 	pendingNowPlayingRequests = new Map<string, { name: string }>()
+	lastFileRequestAt = new Map<string, number>()
+	peerReconnectAttempts = new Map<string, number>()
 
 	constructor() {
 		this.deviceName = `Device ${Math.floor(Math.random() * 1000)}`
@@ -189,19 +187,19 @@ class SyncStore {
 				pc: false,
 				peerTransports: false,
 				earlyIce: false,
-				outboundDc: false,
 				inboundDcs: false,
-				outboundQueue: false,
 				presenceSocket: false,
 				presenceReconnectTimer: false,
 				presenceReconnectAttempts: false,
 				presenceIntentionalClose: false,
-				roomOwnerToken: false,
 				broadcastTimer: false,
 				pingTimer: false,
 				connectTimeout: false,
 				receiveBuffers: false,
 				pendingNowPlayingRequests: false,
+				lastFileRequestAt: false,
+				peerReconnectAttempts: false,
+				suppressNextFileAnnouncement: false,
 			},
 			{ autoBind: true },
 		)
@@ -215,7 +213,6 @@ class SyncStore {
 		this.myGroupCode = (await getSetting<string>('myGroupCode')) ?? null
 		this.joinedGroupCode = (await getSetting<string>('joinedGroupCode')) ?? null
 		this.wasSharing = (await getSetting<boolean>('wasSharing')) ?? false
-		this.roomOwnerToken = (await getSetting<string>('roomOwnerToken')) ?? null
 		const deviceName = await getSetting<string>('deviceName')
 		if (typeof deviceName === 'string' && deviceName.length > 0) {
 			this.deviceName = deviceName
@@ -245,14 +242,6 @@ class SyncStore {
 			this.myGroupCode = makeRoomCode()
 			await setSetting('myGroupCode', this.myGroupCode)
 		}
-		if (!this.roomOwnerToken) {
-			const bytes = new Uint8Array(32)
-			crypto.getRandomValues(bytes)
-			this.roomOwnerToken = [...bytes]
-				.map((byte) => byte.toString(16).padStart(2, '0'))
-				.join('')
-			await setSetting('roomOwnerToken', this.roomOwnerToken)
-		}
 		return this.myGroupCode
 	}
 
@@ -264,8 +253,8 @@ class SyncStore {
 	/** Share our own group; showing the QR implicitly starts it. */
 	async startSharing() {
 		const code = await this.ensureMyGroup()
-		await this.createHostSession(code)
-		if (this.role === 'host' && this.connectionState === 'connected') {
+		await this.connectGroup(code)
+		if (this.role === 'peer' && this.connectionState === 'connected') {
 			this.joinedGroupCode = null
 			this.wasSharing = true
 			await setSetting('joinedGroupCode', null)
@@ -275,8 +264,8 @@ class SyncStore {
 
 	/** Join someone else's group. */
 	async joinGroup(code: string) {
-		await this.joinSession(code)
-		if (this.role === 'follower' && this.connectionState === 'connected') {
+		await this.connectGroup(code)
+		if (this.role === 'peer' && this.connectionState === 'connected') {
 			this.joinedGroupCode = this.roomCode
 			this.wasSharing = false
 			await setSetting('joinedGroupCode', this.roomCode)
@@ -300,31 +289,71 @@ class SyncStore {
 		await setSetting('joinedGroupCode', null)
 	}
 
+	/** Rotate the bearer group capability and start a fresh remembered group. */
+	async createNewGroup() {
+		this.reset()
+		this.myGroupCode = makeRoomCode()
+		this.joinedGroupCode = null
+		this.wasSharing = true
+		await setSetting('myGroupCode', this.myGroupCode)
+		await setSetting('joinedGroupCode', null)
+		await setSetting('wasSharing', true)
+		await this.connectGroup(this.myGroupCode)
+	}
+
 	reconnect() {
-		if (this.role === 'host' && this.roomCode) {
-			void this.createHostSession(this.roomCode)
-		} else if (this.role === 'follower' && this.roomCode) {
-			void this.joinSession(this.roomCode)
-		}
+		if (this.role === 'peer' && this.roomCode) void this.connectGroup(this.roomCode)
+	}
+
+	get coordinatorId(): string | null {
+		if (!this.sessionId) return null
+		const online = [
+			this.sessionId,
+			...this.roomPeers.map((peer) => peer.sessionId),
+		]
+		if (
+			this.coordinationClaim &&
+			online.includes(this.coordinationClaim.claimantId)
+		)
+			return this.coordinationClaim.claimantId
+		return online.sort()[0]
+	}
+
+	get isCoordinator() {
+		return this.role === 'peer' && this.coordinatorId === this.sessionId
 	}
 
 	/** Consume the announced now-playing file (cleared after opening it). */
 	consumePendingNowPlaying() {
 		this.pendingNowPlaying = null
+		this.suppressNextFileAnnouncement = true
 	}
 
 	send(msg: SyncMessage) {
 		const raw = JSON.stringify(msg)
-		if (this.role === 'host') {
-			for (const dc of this.inboundDcs.values()) {
-				if (dc.readyState === 'open') dc.send(raw)
+		for (const dc of this.inboundDcs.values()) {
+			if (dc.readyState === 'open') dc.send(raw)
+		}
+	}
+
+	private async _sendWithBackpressure(msg: SyncMessage) {
+		const raw = JSON.stringify(msg)
+		for (const dc of this.inboundDcs.values()) {
+			if (dc.readyState !== 'open') continue
+			if (dc.bufferedAmount > 512 * 1024) {
+				dc.bufferedAmountLowThreshold = 256 * 1024
+				await new Promise<void>((resolve) => {
+					const done = () => {
+						window.clearTimeout(timeout)
+						dc.removeEventListener('bufferedamountlow', done)
+						resolve()
+					}
+					const timeout = window.setTimeout(done, 2000)
+					dc.addEventListener('bufferedamountlow', done, { once: true })
+				})
 			}
-		} else if (this.outboundDc && this.outboundDc.readyState === 'open') {
-			this.outboundDc.send(raw)
-		} else {
-			if (this.outboundQueue.length >= MAX_OUTBOUND_QUEUE)
-				this.outboundQueue.shift()
-			this.outboundQueue.push(raw)
+			if (dc.readyState === 'open' && dc.bufferedAmount <= 512 * 1024)
+				dc.send(raw)
 		}
 	}
 
@@ -332,16 +361,16 @@ class SyncStore {
 	// Connection setup
 	// ------------------------------------------------------------------
 
-	private async createHostSession(keepCode: string) {
+	private async connectGroup(code: string) {
 		this.reset()
 		this.connectionState = 'connecting'
-		this.role = 'host'
+		this.role = 'peer'
 
 		try {
 			this.sessionId = makeConnectionId()
-			this.roomCode = keepCode
+			this.roomCode = code.toUpperCase()
 			this._startConnectTimeout()
-			await this._connectPresence('host')
+			await this._connectPresence()
 			this._startBroadcastTimer()
 			this._startPing()
 
@@ -349,43 +378,11 @@ class SyncStore {
 			this._clearConnectTimeout()
 			void this.onFileLoaded()
 		} catch (err) {
-			this._fail(err)
-		}
-	}
-
-	private async joinSession(code: string) {
-		this.reset()
-		this.connectionState = 'connecting'
-		this.role = 'follower'
-
-		try {
-			this.roomCode = code.toUpperCase()
-			this.sessionId = makeConnectionId()
-			this._startPing()
-			this._startConnectTimeout()
-			await this._connectPresence('follower')
-			await this._waitForPeerConnection()
-		} catch (err) {
 			this._fail(
 				err,
-				'Could not reach this group. Make sure the owner is sharing and try again.',
+				'Could not reach this group. Check the code and network, then try again.',
 			)
 		}
-	}
-
-	private _waitForPeerConnection(): Promise<void> {
-		return new Promise((resolve, reject) => {
-			const started = Date.now()
-			const check = window.setInterval(() => {
-				if (this.connectionState === 'connected') {
-					window.clearInterval(check)
-					resolve()
-				} else if (Date.now() - started >= CONNECT_TIMEOUT_MS) {
-					window.clearInterval(check)
-					reject(new Error('Connection timed out'))
-				}
-			}, 100)
-		})
 	}
 
 	// ------------------------------------------------------------------
@@ -398,7 +395,7 @@ class SyncStore {
 
 	seekTo(positionMs: number) {
 		setClock({ lastActionAt: Date.now(), lastTimeElapsedMs: positionMs })
-		if (this.role === 'host') {
+		if (this.isCoordinator) {
 			this.broadcastClockState()
 		} else if (this.role !== 'none') {
 			this.send({ type: 'cmd-seek', positionMs: getTimeElapsed() })
@@ -408,7 +405,7 @@ class SyncStore {
 	togglePlayback() {
 		const isPlaying = !clock.isPlaying
 		clock.toggleIsPlaying(isPlaying)
-		if (this.role === 'host') {
+		if (this.isCoordinator) {
 			this.broadcastClockState()
 		} else if (this.role !== 'none') {
 			this.send({ type: isPlaying ? 'cmd-play' : 'cmd-pause' })
@@ -421,7 +418,7 @@ class SyncStore {
 			lastActionAt: Date.now(),
 			lastTimeElapsedMs: getTimeElapsed(),
 		})
-		if (this.role === 'host') {
+		if (this.isCoordinator) {
 			this.broadcastClockState()
 		} else if (this.role !== 'none') {
 			this.send({ type: 'cmd-speed', speed })
@@ -429,17 +426,29 @@ class SyncStore {
 	}
 
 	// ------------------------------------------------------------------
-	// Owner broadcasts
+	// Coordinator broadcasts
 	// ------------------------------------------------------------------
 
 	async onFileLoaded() {
-		if (this.role !== 'host') return
+		if (this.suppressNextFileAnnouncement) {
+			this.suppressNextFileAnnouncement = false
+			return
+		}
+		if (this.role !== 'peer' || !this.sessionId) return
+		if (!this.isCoordinator) {
+			const claim = {
+				term: (this.coordinationClaim?.term ?? 0) + 1,
+				claimantId: this.sessionId,
+			}
+			this.coordinationClaim = claim
+			this.send({ type: 'claim-coordinator', ...claim })
+		}
 		await this.broadcastNowPlaying()
 		await this.broadcastFileList()
 	}
 
 	async broadcastNowPlaying() {
-		if (this.role !== 'host') return
+		if (!this.isCoordinator) return
 		const lines = getFile()
 		const fileId = lines?.[0]?.fileId
 		if (!fileId) return
@@ -449,17 +458,19 @@ class SyncStore {
 	}
 
 	async broadcastFileList() {
-		if (this.role !== 'host') return
+		if (!this.isCoordinator) return
 		const db = await initAndGetDb()
 		const files = await db.getAll('files')
 		this.send({
 			type: 'file-list',
-			files: files.map((file) => ({ id: file.id, name: file.name })),
+			files: files
+				.slice(0, 256)
+				.map((file) => ({ id: file.id, name: file.name.slice(0, 256) })),
 		})
 	}
 
 	async sendFile(fileName: string) {
-		if (this.role !== 'host') return
+		if (!this.isCoordinator) return
 		const db = await initAndGetDb()
 		const file = (await db.getAll('files')).find((f) => f.name === fileName)
 		if (!file) return
@@ -470,9 +481,13 @@ class SyncStore {
 		const text = linesToSrtText(lines)
 		const transferId = nanoid()
 		const totalChunks = Math.max(1, Math.ceil(text.length / CHUNK_SIZE))
+		if (totalChunks > MAX_TRANSFER_CHUNKS) {
+			this.error = 'This subtitle file is too large to sync directly'
+			return
+		}
 
 		for (let i = 0; i < totalChunks; i++) {
-			this.send({
+			await this._sendWithBackpressure({
 				type: 'file-chunk',
 				transferId,
 				chunkIndex: i,
@@ -484,12 +499,14 @@ class SyncStore {
 	}
 
 	sendFileDeleted(fileId: string, fileName: string) {
-		if (this.role !== 'host') return
-		this.send({ type: 'file-deleted', fileId, fileName })
+		// Deletion stays local. A group peer must never be able to delete another
+		// device's IndexedDB content, even when it is the current coordinator.
+		void fileId
+		void fileName
 	}
 
 	broadcastClockState() {
-		if (this.role !== 'host' || this.connectionState !== 'connected') return
+		if (!this.isCoordinator || this.connectionState !== 'connected') return
 		this.send({
 			type: 'state-clock',
 			isPlaying: clock.isPlaying,
@@ -502,11 +519,32 @@ class SyncStore {
 	// Incoming messages
 	// ------------------------------------------------------------------
 
-	private _handleMessage(value: unknown) {
+	private _handleMessage(value: unknown, peerId: string) {
 		if (!value || typeof value !== 'object' || Array.isArray(value)) return
 		const msg = value as SyncMessage
+		if (msg.type === 'claim-coordinator') {
+			if (
+				msg.claimantId !== peerId ||
+				!Number.isSafeInteger(msg.term) ||
+				msg.term < 1 ||
+				msg.term > 1_000_000_000
+			)
+				return
+			const current = this.coordinationClaim
+			if (
+				!current ||
+				msg.term > current.term ||
+				(msg.term === current.term && msg.claimantId > current.claimantId)
+			)
+				this.coordinationClaim = {
+					term: msg.term,
+					claimantId: msg.claimantId,
+				}
+			return
+		}
+		const fromCoordinator = peerId === this.coordinatorId
 		const allowed =
-			this.role === 'host'
+			this.isCoordinator
 				? new Set([
 						'cmd-play',
 						'cmd-pause',
@@ -518,26 +556,49 @@ class SyncStore {
 						'ping',
 						'pong',
 					])
-				: new Set([
+				: fromCoordinator
+					? new Set([
 						'state-clock',
 						'now-playing',
 						'file-list',
 						'file-chunk',
-						'file-deleted',
 						'ping',
 						'pong',
 					])
+					: new Set(['ping', 'pong'])
 		if (!allowed.has(msg.type)) return
 		switch (msg.type) {
 			case 'state-clock':
+				if (
+					typeof msg.isPlaying !== 'boolean' ||
+					!Number.isFinite(msg.positionMs) ||
+					msg.positionMs < 0 ||
+					!Number.isFinite(msg.playSpeed) ||
+					msg.playSpeed < 0.1 ||
+					msg.playSpeed > 5
+				)
+					return
 				this._applyClockState(msg)
 				return
 			case 'now-playing':
+				if (typeof msg.name !== 'string' || msg.name.length > 256) return
 				void this._handleNowPlaying(msg).catch((err) =>
 					console.error('now-playing handler failed', err),
 				)
 				return
 			case 'file-list':
+				if (
+					!Array.isArray(msg.files) ||
+					msg.files.length > 256 ||
+					msg.files.some(
+						(file) =>
+							!file ||
+							typeof file.id !== 'string' ||
+							typeof file.name !== 'string' ||
+							file.name.length > 256,
+					)
+				)
+					return
 				void this._handleFileList(msg).catch((err) =>
 					console.error('file-list handler failed', err),
 				)
@@ -545,17 +606,12 @@ class SyncStore {
 			case 'file-chunk':
 				this._handleFileChunk(msg)
 				return
-			case 'file-deleted':
-				void this._handleFileDeleted(msg).catch((err) =>
-					console.error('file-deleted handler failed', err),
-				)
-				return
 			case 'ping':
 				this.send({ type: 'pong', sentAt: msg.sentAt })
 				return
 		}
 
-		if (this.role !== 'host') return
+		if (!this.isCoordinator) return
 
 		switch (msg.type) {
 			case 'cmd-play':
@@ -571,6 +627,7 @@ class SyncStore {
 				}
 				return
 			case 'cmd-seek':
+				if (!Number.isFinite(msg.positionMs) || msg.positionMs < 0) return
 				setClock({
 					lastActionAt: Date.now(),
 					lastTimeElapsedMs: msg.positionMs,
@@ -578,6 +635,12 @@ class SyncStore {
 				this.broadcastClockState()
 				return
 			case 'cmd-speed':
+				if (
+					!Number.isFinite(msg.speed) ||
+					msg.speed < 0.1 ||
+					msg.speed > 5
+				)
+					return
 				setClock({
 					playSpeed: msg.speed,
 					lastActionAt: Date.now(),
@@ -592,6 +655,11 @@ class SyncStore {
 				this._handlePeerLeave(msg.deviceName)
 				return
 			case 'request-file':
+				if (typeof msg.fileName !== 'string' || msg.fileName.length > 256)
+					return
+				if (Date.now() - (this.lastFileRequestAt.get(peerId) ?? 0) < 2000)
+					return
+				this.lastFileRequestAt.set(peerId, Date.now())
 				void this.sendFile(msg.fileName)
 				return
 		}
@@ -688,24 +756,6 @@ class SyncStore {
 		}
 	}
 
-	private async _handleFileDeleted(
-		msg: Extract<SyncMessage, { type: 'file-deleted' }>,
-	) {
-		const db = await initAndGetDb()
-		const file = (await db.getAll('files')).find((f) => f.name === msg.fileName)
-		if (!file) return
-		const tx = db.transaction(['files', 'lines'], 'readwrite')
-		tx.objectStore('files').delete(file.id)
-		const keys = await tx
-			.objectStore('lines')
-			.index('by-file-id')
-			.getAllKeys(file.id)
-		for (const key of keys) {
-			tx.objectStore('lines').delete(key)
-		}
-		await tx.done
-	}
-
 	private _updateTransfers() {
 		this.transfers = [...this.receiveBuffers.values()].map((buffer) => ({
 			fileName: buffer.fileName,
@@ -736,10 +786,11 @@ class SyncStore {
 	private _monitorConnection(pc: RTCPeerConnection, peerId: string) {
 		pc.onconnectionstatechange = () => {
 			if (pc.connectionState === 'connected') {
+				this.peerReconnectAttempts.set(peerId, 0)
 				this.connectionState = 'connected'
 				this.presenceReconnectAttempts = 0
 				this._clearConnectTimeout()
-				if (this.role === 'follower')
+				if (this.sessionId && this.sessionId > peerId)
 					this._sendSignal({
 						type: 'ready',
 						to: peerId,
@@ -754,14 +805,14 @@ class SyncStore {
 				this.roomPeers = this.roomPeers.map((peer) =>
 					peer.sessionId === peerId ? { ...peer, connected: false } : peer,
 				)
+				const retries = this.peerReconnectAttempts.get(peerId) ?? 0
 				if (
-					this.role === 'follower' &&
+					retries < 3 &&
 					!this.presenceIntentionalClose &&
 					this.roomCode
 				) {
-					this.connectionState = 'connecting'
-					this._startConnectTimeout()
-					this._schedulePresenceReconnect('follower')
+					this.peerReconnectAttempts.set(peerId, retries + 1)
+					this._schedulePresenceReconnect()
 				}
 			}
 		}
@@ -770,28 +821,28 @@ class SyncStore {
 	private _attachDataChannel(dc: RTCDataChannel, peerId: string) {
 		dc.onmessage = (event) => {
 			try {
-				this._handleMessage(JSON.parse(event.data))
+				if (
+					typeof event.data !== 'string' ||
+					event.data.length > MAX_DATA_MESSAGE_CHARS
+				)
+					return
+				this._handleMessage(JSON.parse(event.data), peerId)
 			} catch (err) {
 				console.warn('Ignoring malformed sync message', err)
 			}
 		}
 		dc.onopen = () => {
-			if (this.role === 'follower') this.outboundDc = dc
-			else this.inboundDcs.set(peerId, dc)
+			this.inboundDcs.set(peerId, dc)
 			this.roomPeers = this.roomPeers.map((peer) =>
 				peer.sessionId === peerId ? { ...peer, connected: true } : peer,
 			)
-			while (this.outboundQueue.length > 0) {
-				const raw = this.outboundQueue.shift()
-				if (raw !== undefined) dc.send(raw)
-			}
-			if (this.role === 'follower')
-				this.send({ type: 'join', deviceName: this.deviceName })
-			else void this._handlePeerJoin()
+			if (this.coordinationClaim?.claimantId === this.sessionId)
+				dc.send(JSON.stringify({ type: 'claim-coordinator', ...this.coordinationClaim }))
+			this.send({ type: 'join', deviceName: this.deviceName })
+			if (this.isCoordinator) void this._handlePeerJoin()
 		}
 		dc.onclose = () => {
-			this.inboundDcs.delete(peerId)
-			if (this.outboundDc === dc) this.outboundDc = null
+			if (this.inboundDcs.get(peerId) === dc) this.inboundDcs.delete(peerId)
 		}
 	}
 
@@ -808,7 +859,7 @@ class SyncStore {
 			transport.pendingIce.push(...early.candidates)
 		this.earlyIce.delete(peerId)
 		this.peerTransports.set(peerId, transport)
-		if (this.role === 'follower') this.pc = pc
+		this.pc = pc
 		this._monitorConnection(pc, peerId)
 		pc.onicecandidate = (event) => {
 			if (event.candidate)
@@ -838,30 +889,41 @@ class SyncStore {
 
 	private async _handleSignal(message: SignalMessage) {
 		if (message.type === 'peers') {
+			const wasCoordinator = this.isCoordinator
 			const signaled = message.peers
 				.filter((peer) => peer.id !== this.sessionId)
 				.map((peer) => ({
 					sessionId: peer.id,
 					name: peer.name,
-					isHost: peer.isHost,
-					connected:
-						this.inboundDcs.has(peer.id) ||
-						(peer.isHost && this.outboundDc?.readyState === 'open'),
+					connected: this.inboundDcs.get(peer.id)?.readyState === 'open',
 				}))
-			const signaledIds = new Set(signaled.map((peer) => peer.sessionId))
-			this.roomPeers = [
-				...signaled,
-				...this.roomPeers.filter(
-					(peer) => peer.connected && !signaledIds.has(peer.sessionId),
-				),
-			]
-			if (this.role === 'host')
-				for (const peer of message.peers)
-					if (!peer.isHost && !this.peerTransports.has(peer.id))
-						void this._offerPeer(peer.id)
+			this.roomPeers = signaled
+			if (
+				this.coordinationClaim &&
+				this.coordinationClaim.claimantId !== this.sessionId &&
+				!signaled.some(
+					(peer) => peer.sessionId === this.coordinationClaim?.claimantId,
+				)
+			)
+				this.coordinationClaim = null
+			if (!wasCoordinator && this.isCoordinator) {
+				this.broadcastClockState()
+				void this.onFileLoaded()
+			}
+			for (const peer of message.peers)
+				if (
+					this.sessionId &&
+					this.sessionId < peer.id &&
+					!this.peerTransports.has(peer.id)
+				)
+					void this._offerPeer(peer.id)
 			return
 		}
-		if (message.type === 'offer' && this.role === 'follower') {
+		if (
+			message.type === 'offer' &&
+			this.sessionId &&
+			message.from < this.sessionId
+		) {
 			const transport = this._newPeer(message.from, message.generation)
 			transport.pc.ondatachannel = (event) =>
 				this._attachDataChannel(event.channel, message.from)
@@ -886,7 +948,7 @@ class SyncStore {
 				})
 			return
 		}
-		if (message.type === 'answer' && this.role === 'host') {
+		if (message.type === 'answer') {
 			await transport.pc.setRemoteDescription(message.sdp)
 			for (const ice of transport.pendingIce.splice(0))
 				await transport.pc.addIceCandidate(ice)
@@ -903,7 +965,7 @@ class SyncStore {
 	// Discovery / presence (one hibernatable Durable Object WebSocket)
 	// ------------------------------------------------------------------
 
-	private _connectPresence(role: Exclude<SyncRole, 'none'>): Promise<void> {
+	private _connectPresence(): Promise<void> {
 		if (!this.roomCode || !this.sessionId) {
 			return Promise.reject(new Error('Room transport is not ready'))
 		}
@@ -912,19 +974,11 @@ class SyncStore {
 		const url = new URL(`${API}/room`, location.origin)
 		url.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
 		url.searchParams.set('code', this.roomCode)
-		url.searchParams.set('role', role)
 		url.searchParams.set('id', this.sessionId)
 		url.searchParams.set('name', this.deviceName.slice(0, 64))
-		const protocols = ['subtitle-sync']
-		if (role === 'host') {
-			if (!this.roomOwnerToken) {
-				return Promise.reject(new Error('Missing room owner credential'))
-			}
-			protocols.push(`host.${this.roomOwnerToken}`)
-		}
 
 		return new Promise((resolve, reject) => {
-			const socket = new WebSocket(url, protocols)
+			const socket = new WebSocket(url, ['subtitle-sync'])
 			this.presenceSocket = socket
 			let settled = false
 			const fail = () => {
@@ -939,7 +993,7 @@ class SyncStore {
 					void this._handleSignal(message).catch((err) =>
 						console.warn('Signal failed', err),
 					)
-					if (role === 'host') this.presenceReconnectAttempts = 0
+					this.presenceReconnectAttempts = 0
 					if (!settled && message.type === 'peers') {
 						settled = true
 						resolve()
@@ -956,11 +1010,10 @@ class SyncStore {
 				if (
 					isCurrentSocket &&
 					!this.presenceIntentionalClose &&
-					this.role === role &&
-					(role === 'host' || this.connectionState !== 'connected') &&
+					this.role === 'peer' &&
 					this.roomCode
 				) {
-					this._schedulePresenceReconnect(role)
+					this._schedulePresenceReconnect()
 				}
 			}
 		})
@@ -971,12 +1024,12 @@ class SyncStore {
 			this.presenceSocket.send(JSON.stringify(message))
 	}
 
-	private _schedulePresenceReconnect(role: Exclude<SyncRole, 'none'>) {
+	private _schedulePresenceReconnect() {
 		if (this.presenceReconnectTimer !== null) return
 		if (
 			this.presenceReconnectAttempts >= MAX_PRESENCE_RECONNECT_ATTEMPTS
 		) {
-			if (role === 'follower' && this.connectionState !== 'connected') {
+			if (this.connectionState !== 'connected') {
 				this.connectionState = 'error'
 				this.error = 'Could not reconnect directly to the other device'
 			}
@@ -986,7 +1039,7 @@ class SyncStore {
 		const delay = Math.min(30_000, 1000 * 2 ** attempt) + Math.random() * 500
 		this.presenceReconnectTimer = window.setTimeout(() => {
 			this.presenceReconnectTimer = null
-			void this._connectPresence(role).catch(() => {})
+			void this._connectPresence().catch(() => {})
 		}, delay)
 	}
 
@@ -1007,7 +1060,7 @@ class SyncStore {
 	private _startBroadcastTimer() {
 		this._stopBroadcastTimer()
 		this.broadcastTimer = window.setInterval(() => {
-			if (this.role === 'host' && clock.isPlaying) {
+			if (this.isCoordinator && clock.isPlaying) {
 				this.broadcastClockState()
 			}
 		}, BROADCAST_INTERVAL_MS)
@@ -1074,12 +1127,11 @@ class SyncStore {
 			dc.close()
 		}
 		this.inboundDcs.clear()
-		this.outboundDc?.close()
-		this.outboundDc = null
-		this.outboundQueue.length = 0
 		for (const transport of this.peerTransports.values()) transport.pc.close()
 		this.peerTransports.clear()
 		this.earlyIce.clear()
+		this.lastFileRequestAt.clear()
+		this.peerReconnectAttempts.clear()
 		this.pc?.close()
 		this.pc = null
 	}
@@ -1092,9 +1144,11 @@ class SyncStore {
 		this.connectionState = 'disconnected'
 		this.error = null
 		this.roomPeers = []
+		this.coordinationClaim = null
 		this.receivedFiles = []
 		this.transfers = []
 		this.pendingNowPlaying = null
+		this.suppressNextFileAnnouncement = false
 	}
 }
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,44 +1,26 @@
 import { Hono } from 'hono'
-import { RoomCoordinator, type RoomSnapshot } from './room-coordinator'
+import { RoomCoordinator } from './room-coordinator'
 
 export { RoomCoordinator } from './room-coordinator'
 
 /**
  * Signaling endpoint for device pairing.
  *
- * This worker ONLY brokers WebRTC session discovery for Cloudflare
- * Realtime SFU. It never touches subtitle content: the only data that
- * passes through here are opaque, ephemeral SFU session IDs and device
- * names. SRT data travels exclusively over the WebRTC data channel.
+ * This worker relays bounded SDP/ICE signaling. SRT and playback data travel
+ * only over direct WebRTC channels.
  *
  * Room presence is coordinated by one hibernatable Durable Object per
  * room code. Idle WebSockets do not keep an object running, and all SRT
- * and clock data remains on Realtime SFU data channels.
+ * and clock data remains on peer-to-peer data channels.
  */
 
 interface Env {
-	APP_ID: string
-	APP_TOKEN: string
 	ASSETS: Fetcher
 	ROOMS: DurableObjectNamespace<RoomCoordinator>
 	SYNC_RATE_LIMITER: RateLimit
 }
 
-const API_BASE = 'https://rtc.live.cloudflare.com/v1/apps'
-const ROOM_CODE_RE = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{10}$/
-const MAX_SFU_BODY_BYTES = 64 * 1024
-const SFU_ROUTES = [
-	{ method: 'POST', pattern: /^\/sessions\/new$/ },
-	{
-		method: 'POST',
-		pattern:
-			/^\/sessions\/[A-Za-z0-9_-]{16,128}\/datachannels\/(?:new|establish)$/,
-	},
-	{
-		method: 'PUT',
-		pattern: /^\/sessions\/[A-Za-z0-9_-]{16,128}\/renegotiate$/,
-	},
-] as const
+const ROOM_CODE_RE = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{20}$/
 
 const app = new Hono<{ Bindings: Env }>()
 
@@ -46,21 +28,6 @@ const allowSyncRequest = async (request: Request, env: Env) => {
 	const client = request.headers.get('CF-Connecting-IP') ?? 'unknown'
 	return (await env.SYNC_RATE_LIMITER.limit({ key: client })).success
 }
-
-app.get('/api/sync', async (c) => {
-	if (!(await allowSyncRequest(c.req.raw, c.env))) {
-		return c.json({ error: 'Too many requests' }, 429)
-	}
-	const action = c.req.query('action')
-	const roomCode = c.req.query('code')?.trim().toUpperCase() ?? ''
-	if (action !== 'lookup-room' || !ROOM_CODE_RE.test(roomCode)) {
-		return c.json({ error: 'Not found' }, 404)
-	}
-	const room = (await c.env.ROOMS.getByName(
-		roomCode,
-	).getSnapshot()) as RoomSnapshot | null
-	return room ? c.json(room) : c.json({ error: 'Room not found' }, 404)
-})
 
 app.get('/api/sync/room', async (c) => {
 	if (!(await allowSyncRequest(c.req.raw, c.env))) {
@@ -75,56 +42,6 @@ app.get('/api/sync/room', async (c) => {
 		return c.json({ error: 'Forbidden' }, 403)
 	}
 	return await c.env.ROOMS.getByName(roomCode).fetch(c.req.raw)
-})
-
-// Transparent proxy for the SFU API. The app token never leaves the
-// server; clients talk to /api/sync/sfu/... only.
-app.all('/api/sync/sfu/*', async (c) => {
-	if (!(await allowSyncRequest(c.req.raw, c.env))) {
-		return c.json({ error: 'Too many requests' }, 429)
-	}
-	const sfuPath = c.req.path.replace(/^\/api\/sync\/sfu/, '')
-	if (
-		!SFU_ROUTES.some(
-			(route) => route.method === c.req.method && route.pattern.test(sfuPath),
-		)
-	) {
-		return c.json({ error: 'Not found' }, 404)
-	}
-	const origin = c.req.header('Origin')
-	if (origin && origin !== new URL(c.req.url).origin) {
-		return c.json({ error: 'Forbidden' }, 403)
-	}
-	const contentLength = Number(c.req.header('Content-Length'))
-	const createsSession = c.req.method === 'POST' && sfuPath === '/sessions/new'
-	if (
-		(!createsSession &&
-			c.req.header('Content-Type')?.split(';', 1)[0] !== 'application/json') ||
-		!Number.isSafeInteger(contentLength) ||
-		contentLength < 0 ||
-		contentLength > MAX_SFU_BODY_BYTES
-	) {
-		return c.json({ error: 'Invalid request body' }, 413)
-	}
-	if (!c.env.APP_TOKEN) {
-		return c.json(
-			{ error: 'SFU token not configured (missing APP_TOKEN secret)' },
-			500,
-		)
-	}
-	const request = c.req.raw
-	const response = await fetch(`${API_BASE}/${c.env.APP_ID}${sfuPath}`, {
-		method: request.method,
-		headers: {
-			Authorization: `Bearer ${c.env.APP_TOKEN}`,
-			'Content-Type': 'application/json',
-		},
-		body: request.body,
-	})
-	return new Response(response.body, {
-		status: response.status,
-		headers: { 'Content-Type': 'application/json' },
-	})
 })
 
 // Serve the SPA for everything else.

--- a/worker/room-coordinator.ts
+++ b/worker/room-coordinator.ts
@@ -1,207 +1,224 @@
 import { DurableObject } from 'cloudflare:workers'
 
-const MAX_ROOM_CONNECTIONS = 8
-const MAX_NAME_LENGTH = 64
-const SESSION_ID_RE = /^[A-Za-z0-9_-]{16,128}$/
+const MAX_CONNECTIONS = 8
+const MAX_MESSAGE_BYTES = 32 * 1024
+const MAX_FOLLOWER_ICE_MESSAGES = 64
+const MAX_FOLLOWER_SIGNAL_MESSAGES = 80
+const MAX_HOST_ICE_MESSAGES = 384
+const MAX_HOST_SIGNAL_MESSAGES = 512
+const ID_RE = /^[A-Fa-f0-9]{32}$/
 const HOST_TOKEN_RE = /^host\.([A-Fa-f0-9]{64})$/
 
-export type RoomRole = 'host' | 'follower'
-
-export interface RoomPeer {
-	sessionId: string
+type Role = 'host' | 'follower'
+interface Attachment {
+	id: string
+	role: Role
 	name: string
-	isHost: boolean
-}
-
-interface SocketAttachment extends RoomPeer {
+	iceMessages: number
+	signalMessages: number
+	negotiated?: boolean
 	superseded?: boolean
 }
 
-export interface RoomSnapshot {
-	hostSessionId: string
-	peers: RoomPeer[]
-}
-
-const socketAttachment = (socket: WebSocket): SocketAttachment | null => {
-	const value: unknown = socket.deserializeAttachment()
+const attachment = (ws: WebSocket): Attachment | null => {
+	const value: unknown = ws.deserializeAttachment()
 	if (!value || typeof value !== 'object') return null
-	const peer = value as Partial<SocketAttachment>
+	const item = value as Partial<Attachment>
 	if (
-		typeof peer.sessionId !== 'string' ||
-		typeof peer.name !== 'string' ||
-		typeof peer.isHost !== 'boolean'
-	) {
+		!ID_RE.test(item.id ?? '') ||
+		(item.role !== 'host' && item.role !== 'follower')
+	)
 		return null
-	}
 	return {
-		sessionId: peer.sessionId,
-		name: peer.name,
-		isHost: peer.isHost,
-		superseded: peer.superseded === true,
+		id: item.id!,
+		role: item.role,
+		name: typeof item.name === 'string' ? item.name : 'Device',
+		iceMessages: typeof item.iceMessages === 'number' ? item.iceMessages : 0,
+		signalMessages:
+			typeof item.signalMessages === 'number' ? item.signalMessages : 0,
+		superseded: item.superseded === true,
+		negotiated: item.negotiated === true,
 	}
 }
 
 export class RoomCoordinator extends DurableObject<Record<string, never>> {
-	getSnapshot(): RoomSnapshot | null {
-		const peers = this.peers()
-		const host = peers.find((peer) => peer.isHost)
-		return host ? { hostSessionId: host.sessionId, peers } : null
-	}
-
 	async fetch(request: Request): Promise<Response> {
-		if (request.headers.get('Upgrade')?.toLowerCase() !== 'websocket') {
-			return Response.json(
-				{ error: 'WebSocket upgrade required' },
-				{ status: 426 },
-			)
-		}
-
+		if (request.headers.get('Upgrade')?.toLowerCase() !== 'websocket')
+			return new Response('Upgrade required', { status: 426 })
 		const url = new URL(request.url)
-		const role = url.searchParams.get('role')
-		const sessionId = url.searchParams.get('sessionId') ?? ''
+		const role = url.searchParams.get('role') as Role | null
+		const id = url.searchParams.get('id') ?? ''
 		const rawName = url.searchParams.get('name') ?? ''
-		const name = rawName.trim().slice(0, MAX_NAME_LENGTH) || 'Device'
 		if (
 			(role !== 'host' && role !== 'follower') ||
-			!SESSION_ID_RE.test(sessionId) ||
-			rawName.length > MAX_NAME_LENGTH
-		) {
-			return Response.json(
-				{ error: 'Invalid room connection' },
-				{ status: 400 },
-			)
-		}
+			!ID_RE.test(id) ||
+			rawName.length > 64
+		)
+			return new Response('Invalid connection', { status: 400 })
 
-		const sockets = this.ctx.getWebSockets()
-		const active = sockets
-			.map((socket) => ({ socket, peer: socketAttachment(socket) }))
-			.filter(
-				(entry): entry is { socket: WebSocket; peer: SocketAttachment } =>
-					entry.peer !== null && !entry.peer.superseded,
-			)
-		const host = active.find(({ peer }) => peer.isHost)
 		const hostToken = request.headers
 			.get('Sec-WebSocket-Protocol')
 			?.split(',')
-			.map((value) => value.trim())
-			.find((value) => HOST_TOKEN_RE.test(value))
-
+			.map((v) => v.trim())
+			.find((v) => HOST_TOKEN_RE.test(v))
 		if (role === 'host') {
-			if (!hostToken) {
-				return Response.json(
-					{ error: 'Missing host credential' },
-					{ status: 401 },
-				)
-			}
-			const tokenHash = await sha256(hostToken)
-			const ownerHash = await this.ctx.storage.get<string>('ownerTokenHash')
-			if (ownerHash && ownerHash !== tokenHash) {
-				return Response.json(
-					{ error: 'Room owner credential rejected' },
-					{ status: 403 },
-				)
-			}
-			if (!ownerHash) await this.ctx.storage.put('ownerTokenHash', tokenHash)
-			if (host) {
-				if (!this.ctx.getTags(host.socket).includes(hostToken)) {
-					return Response.json(
-						{ error: 'Room already has a host' },
-						{ status: 409 },
-					)
-				}
-				host.peer.superseded = true
-				host.socket.serializeAttachment(host.peer)
-				host.socket.close(1000, 'Replaced by reconnect')
-			}
-		} else if (!host) {
-			return Response.json({ error: 'Room not found' }, { status: 404 })
+			if (!hostToken)
+				return new Response('Missing owner credential', { status: 401 })
+			const hash = await sha256(hostToken)
+			const authorized = await this.ctx.storage.transaction(async (txn) => {
+				const current = await txn.get<string>('ownerTokenHash')
+				if (current && current !== hash) return false
+				if (!current) await txn.put('ownerTokenHash', hash)
+				return true
+			})
+			if (!authorized)
+				return new Response('Owner credential rejected', { status: 403 })
 		}
 
-		const duplicate = active.find(({ peer }) => peer.sessionId === sessionId)
-		if (duplicate && duplicate !== host) {
-			return Response.json(
-				{ error: 'Session already connected' },
-				{ status: 409 },
-			)
+		let sockets = this.activeSockets()
+		const host = sockets.find(({ state }) => state.role === 'host')
+		if (role === 'follower' && !host)
+			return new Response('Room not found', { status: 404 })
+		if (role === 'host' && host) {
+			if (!hostToken || !this.ctx.getTags(host.ws).includes(hostToken))
+				return new Response('Room already hosted', { status: 409 })
+			host.state.superseded = true
+			host.ws.serializeAttachment(host.state)
+			host.ws.close(1000, 'Host reconnected')
+			sockets = this.activeSockets()
 		}
-		if (active.length - (duplicate ? 1 : 0) >= MAX_ROOM_CONNECTIONS) {
-			return Response.json({ error: 'Room is full' }, { status: 429 })
-		}
+		if (sockets.some(({ state }) => state.id === id))
+			return new Response('Duplicate connection', { status: 409 })
+		if (sockets.length >= MAX_CONNECTIONS)
+			return new Response('Room full', { status: 429 })
 
 		const pair = new WebSocketPair()
-		const client = pair[0]
-		const server = pair[1]
-		const peer: SocketAttachment = { sessionId, name, isHost: role === 'host' }
-		server.serializeAttachment(peer)
+		const state: Attachment = {
+			id,
+			role,
+			name: rawName.trim() || 'Device',
+			iceMessages: 0,
+			signalMessages: 0,
+		}
+		pair[1].serializeAttachment(state)
 		this.ctx.acceptWebSocket(
-			server,
-			role === 'host' && hostToken ? ['host', hostToken] : ['follower'],
+			pair[1],
+			role === 'host' && hostToken ? [role, hostToken] : [role],
 		)
-		this.broadcastSnapshot()
-
+		this.sendPeers()
 		return new Response(null, {
 			status: 101,
-			webSocket: client,
+			webSocket: pair[0],
 			headers: { 'Sec-WebSocket-Protocol': 'subtitle-sync' },
 		})
 	}
 
-	webSocketMessage(socket: WebSocket): void {
-		// Presence is server-driven. Closing clients that send application data
-		// prevents this socket from becoming an unbounded relay or wake-up source.
-		socket.close(1008, 'Client messages are not accepted')
+	webSocketMessage(ws: WebSocket, raw: string | ArrayBuffer): void {
+		if (
+			typeof raw !== 'string' ||
+			raw.length > MAX_MESSAGE_BYTES ||
+			new TextEncoder().encode(raw).byteLength > MAX_MESSAGE_BYTES
+		)
+			return ws.close(1009, 'Invalid message')
+		const sender = attachment(ws)
+		if (!sender) return ws.close(1008, 'Invalid sender')
+		let parsed: unknown
+		try {
+			parsed = JSON.parse(raw)
+		} catch {
+			return ws.close(1007, 'Invalid JSON')
+		}
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+			return ws.close(1008, 'Invalid signal')
+		const msg = parsed as {
+			type?: string
+			to?: string
+			generation?: string
+			sdp?: unknown
+			candidates?: unknown
+		}
+		if (
+			!['offer', 'answer', 'ice', 'ready', 'cancel'].includes(msg.type ?? '') ||
+			!ID_RE.test(msg.to ?? '') ||
+			!ID_RE.test(msg.generation ?? '')
+		)
+			return ws.close(1008, 'Invalid signal')
+		const maxSignals =
+			sender.role === 'host'
+				? MAX_HOST_SIGNAL_MESSAGES
+				: MAX_FOLLOWER_SIGNAL_MESSAGES
+		if (++sender.signalMessages > maxSignals)
+			return ws.close(1008, 'Too many signals')
+		if (msg.type === 'ice') {
+			const maxIce =
+				sender.role === 'host'
+					? MAX_HOST_ICE_MESSAGES
+					: MAX_FOLLOWER_ICE_MESSAGES
+			if (++sender.iceMessages > maxIce)
+				return ws.close(1008, 'Too many candidates')
+		}
+		if (
+			(msg.type === 'offer' && sender.role !== 'host') ||
+			((msg.type === 'answer' || msg.type === 'ready') &&
+				sender.role !== 'follower')
+		)
+			return ws.close(1008, 'Invalid signal direction')
+		ws.serializeAttachment(sender)
+		const target = this.activeSockets().find(({ state }) => state.id === msg.to)
+		if (!target || target.state.role === sender.role)
+			return ws.close(1008, 'Invalid target')
+		target.ws.send(JSON.stringify({ ...msg, from: sender.id }))
+		if (msg.type === 'ready' && sender.role === 'follower') {
+			sender.negotiated = true
+			ws.serializeAttachment(sender)
+			ws.close(1000, 'P2P connected')
+		}
 	}
 
-	webSocketClose(socket: WebSocket): void {
-		this.removeSocket(socket)
+	webSocketClose(ws: WebSocket): void {
+		this.remove(ws)
+	}
+	webSocketError(ws: WebSocket): void {
+		this.remove(ws)
 	}
 
-	webSocketError(socket: WebSocket): void {
-		this.removeSocket(socket)
-	}
-
-	private peers(exclude?: WebSocket): RoomPeer[] {
+	private activeSockets() {
 		return this.ctx
 			.getWebSockets()
-			.filter((socket) => socket !== exclude)
-			.map(socketAttachment)
+			.map((ws) => ({ ws, state: attachment(ws) }))
 			.filter(
-				(peer): peer is SocketAttachment => peer !== null && !peer.superseded,
+				(item): item is { ws: WebSocket; state: Attachment } =>
+					!!item.state && !item.state.superseded,
 			)
-			.map(({ sessionId, name, isHost }) => ({ sessionId, name, isHost }))
 	}
-
-	private broadcastSnapshot(exclude?: WebSocket): void {
-		const peers = this.peers(exclude)
-		const host = peers.find((peer) => peer.isHost)
-		const snapshot = host ? { hostSessionId: host.sessionId, peers } : null
-		if (!snapshot) return
-		const message = JSON.stringify({ type: 'snapshot', ...snapshot })
-		for (const socket of this.ctx.getWebSockets()) {
-			const peer = socketAttachment(socket)
-			if (!peer?.superseded) socket.send(message)
-		}
+	private sendPeers(exclude?: WebSocket) {
+		const peers = this.activeSockets()
+			.filter(({ ws }) => ws !== exclude)
+			.map(({ state }) => ({
+				id: state.id,
+				name: state.name,
+				isHost: state.role === 'host',
+			}))
+		const message = JSON.stringify({ type: 'peers', peers })
+		for (const { ws } of this.activeSockets())
+			if (ws !== exclude) ws.send(message)
 	}
-
-	private removeSocket(socket: WebSocket): void {
-		const departed = socketAttachment(socket)
-		if (!departed || departed.superseded) return
-		if (departed.isHost) {
-			for (const follower of this.ctx.getWebSockets('follower')) {
+	private remove(ws: WebSocket) {
+		const state = attachment(ws)
+		if (!state || state.superseded) return
+		if (state.negotiated) return
+		if (state.role === 'host')
+			for (const follower of this.ctx.getWebSockets('follower'))
 				follower.close(1001, 'Host left')
-			}
-			return
-		}
-		this.broadcastSnapshot(socket)
+		else this.sendPeers(ws)
 	}
 }
 
-const sha256 = async (value: string): Promise<string> => {
-	const digest = await crypto.subtle.digest(
-		'SHA-256',
-		new TextEncoder().encode(value),
-	)
-	return [...new Uint8Array(digest)]
-		.map((byte) => byte.toString(16).padStart(2, '0'))
+const sha256 = async (value: string) =>
+	[
+		...new Uint8Array(
+			await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)),
+		),
+	]
+		.map((b) => b.toString(16).padStart(2, '0'))
 		.join('')
-}

--- a/worker/room-coordinator.ts
+++ b/worker/room-coordinator.ts
@@ -1,43 +1,29 @@
 import { DurableObject } from 'cloudflare:workers'
 
-const MAX_CONNECTIONS = 8
+const MAX_CONNECTIONS = 5
 const MAX_MESSAGE_BYTES = 32 * 1024
-const MAX_FOLLOWER_ICE_MESSAGES = 64
-const MAX_FOLLOWER_SIGNAL_MESSAGES = 80
-const MAX_HOST_ICE_MESSAGES = 384
-const MAX_HOST_SIGNAL_MESSAGES = 512
+const MAX_ICE_MESSAGES = 256
+const MAX_SIGNAL_MESSAGES = 320
 const ID_RE = /^[A-Fa-f0-9]{32}$/
-const HOST_TOKEN_RE = /^host\.([A-Fa-f0-9]{64})$/
 
-type Role = 'host' | 'follower'
 interface Attachment {
 	id: string
-	role: Role
 	name: string
 	iceMessages: number
 	signalMessages: number
-	negotiated?: boolean
-	superseded?: boolean
 }
 
 const attachment = (ws: WebSocket): Attachment | null => {
 	const value: unknown = ws.deserializeAttachment()
 	if (!value || typeof value !== 'object') return null
 	const item = value as Partial<Attachment>
-	if (
-		!ID_RE.test(item.id ?? '') ||
-		(item.role !== 'host' && item.role !== 'follower')
-	)
-		return null
+	if (!ID_RE.test(item.id ?? '')) return null
 	return {
 		id: item.id!,
-		role: item.role,
 		name: typeof item.name === 'string' ? item.name : 'Device',
 		iceMessages: typeof item.iceMessages === 'number' ? item.iceMessages : 0,
 		signalMessages:
 			typeof item.signalMessages === 'number' ? item.signalMessages : 0,
-		superseded: item.superseded === true,
-		negotiated: item.negotiated === true,
 	}
 }
 
@@ -46,65 +32,26 @@ export class RoomCoordinator extends DurableObject<Record<string, never>> {
 		if (request.headers.get('Upgrade')?.toLowerCase() !== 'websocket')
 			return new Response('Upgrade required', { status: 426 })
 		const url = new URL(request.url)
-		const role = url.searchParams.get('role') as Role | null
 		const id = url.searchParams.get('id') ?? ''
 		const rawName = url.searchParams.get('name') ?? ''
-		if (
-			(role !== 'host' && role !== 'follower') ||
-			!ID_RE.test(id) ||
-			rawName.length > 64
-		)
+		if (!ID_RE.test(id) || rawName.length > 64)
 			return new Response('Invalid connection', { status: 400 })
 
-		const hostToken = request.headers
-			.get('Sec-WebSocket-Protocol')
-			?.split(',')
-			.map((v) => v.trim())
-			.find((v) => HOST_TOKEN_RE.test(v))
-		if (role === 'host') {
-			if (!hostToken)
-				return new Response('Missing owner credential', { status: 401 })
-			const hash = await sha256(hostToken)
-			const authorized = await this.ctx.storage.transaction(async (txn) => {
-				const current = await txn.get<string>('ownerTokenHash')
-				if (current && current !== hash) return false
-				if (!current) await txn.put('ownerTokenHash', hash)
-				return true
-			})
-			if (!authorized)
-				return new Response('Owner credential rejected', { status: 403 })
-		}
-
-		let sockets = this.activeSockets()
-		const host = sockets.find(({ state }) => state.role === 'host')
-		if (role === 'follower' && !host)
-			return new Response('Room not found', { status: 404 })
-		if (role === 'host' && host) {
-			if (!hostToken || !this.ctx.getTags(host.ws).includes(hostToken))
-				return new Response('Room already hosted', { status: 409 })
-			host.state.superseded = true
-			host.ws.serializeAttachment(host.state)
-			host.ws.close(1000, 'Host reconnected')
-			sockets = this.activeSockets()
-		}
+		const sockets = this.activeSockets()
 		if (sockets.some(({ state }) => state.id === id))
 			return new Response('Duplicate connection', { status: 409 })
 		if (sockets.length >= MAX_CONNECTIONS)
-			return new Response('Room full', { status: 429 })
+			return new Response('Group full', { status: 429 })
 
 		const pair = new WebSocketPair()
 		const state: Attachment = {
 			id,
-			role,
 			name: rawName.trim() || 'Device',
 			iceMessages: 0,
 			signalMessages: 0,
 		}
 		pair[1].serializeAttachment(state)
-		this.ctx.acceptWebSocket(
-			pair[1],
-			role === 'host' && hostToken ? [role, hostToken] : [role],
-		)
+		this.ctx.acceptWebSocket(pair[1])
 		this.sendPeers()
 		return new Response(null, {
 			status: 101,
@@ -134,45 +81,29 @@ export class RoomCoordinator extends DurableObject<Record<string, never>> {
 			type?: string
 			to?: string
 			generation?: string
-			sdp?: unknown
-			candidates?: unknown
 		}
 		if (
 			!['offer', 'answer', 'ice', 'ready', 'cancel'].includes(msg.type ?? '') ||
 			!ID_RE.test(msg.to ?? '') ||
-			!ID_RE.test(msg.generation ?? '')
+			!ID_RE.test(msg.generation ?? '') ||
+			msg.to === sender.id
 		)
 			return ws.close(1008, 'Invalid signal')
-		const maxSignals =
-			sender.role === 'host'
-				? MAX_HOST_SIGNAL_MESSAGES
-				: MAX_FOLLOWER_SIGNAL_MESSAGES
-		if (++sender.signalMessages > maxSignals)
+		if (++sender.signalMessages > MAX_SIGNAL_MESSAGES)
 			return ws.close(1008, 'Too many signals')
-		if (msg.type === 'ice') {
-			const maxIce =
-				sender.role === 'host'
-					? MAX_HOST_ICE_MESSAGES
-					: MAX_FOLLOWER_ICE_MESSAGES
-			if (++sender.iceMessages > maxIce)
-				return ws.close(1008, 'Too many candidates')
-		}
-		if (
-			(msg.type === 'offer' && sender.role !== 'host') ||
-			((msg.type === 'answer' || msg.type === 'ready') &&
-				sender.role !== 'follower')
-		)
-			return ws.close(1008, 'Invalid signal direction')
+		if (msg.type === 'ice' && ++sender.iceMessages > MAX_ICE_MESSAGES)
+			return ws.close(1008, 'Too many candidates')
 		ws.serializeAttachment(sender)
+
 		const target = this.activeSockets().find(({ state }) => state.id === msg.to)
-		if (!target || target.state.role === sender.role)
-			return ws.close(1008, 'Invalid target')
-		target.ws.send(JSON.stringify({ ...msg, from: sender.id }))
-		if (msg.type === 'ready' && sender.role === 'follower') {
-			sender.negotiated = true
-			ws.serializeAttachment(sender)
-			ws.close(1000, 'P2P connected')
-		}
+		if (!target) return ws.close(1008, 'Invalid target')
+		if (
+			(msg.type === 'offer' && sender.id > target.state.id) ||
+			((msg.type === 'answer' || msg.type === 'ready') &&
+				sender.id < target.state.id)
+		)
+			return ws.close(1008, 'Invalid negotiation direction')
+		target.ws.send(JSON.stringify({ ...parsed, from: sender.id }))
 	}
 
 	webSocketClose(ws: WebSocket): void {
@@ -188,37 +119,22 @@ export class RoomCoordinator extends DurableObject<Record<string, never>> {
 			.map((ws) => ({ ws, state: attachment(ws) }))
 			.filter(
 				(item): item is { ws: WebSocket; state: Attachment } =>
-					!!item.state && !item.state.superseded,
+					!!item.state,
 			)
 	}
+
 	private sendPeers(exclude?: WebSocket) {
 		const peers = this.activeSockets()
 			.filter(({ ws }) => ws !== exclude)
-			.map(({ state }) => ({
-				id: state.id,
-				name: state.name,
-				isHost: state.role === 'host',
-			}))
+			.map(({ state }) => ({ id: state.id, name: state.name }))
 		const message = JSON.stringify({ type: 'peers', peers })
 		for (const { ws } of this.activeSockets())
 			if (ws !== exclude) ws.send(message)
 	}
+
 	private remove(ws: WebSocket) {
 		const state = attachment(ws)
-		if (!state || state.superseded) return
-		if (state.negotiated) return
-		if (state.role === 'host')
-			for (const follower of this.ctx.getWebSockets('follower'))
-				follower.close(1001, 'Host left')
-		else this.sendPeers(ws)
+		if (!state) return
+		this.sendPeers(ws)
 	}
 }
-
-const sha256 = async (value: string) =>
-	[
-		...new Uint8Array(
-			await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)),
-		),
-	]
-		.map((b) => b.toString(16).padStart(2, '0'))
-		.join('')

--- a/wrangler.json
+++ b/wrangler.json
@@ -9,9 +9,6 @@
     "not_found_handling": "single-page-application",
     "run_worker_first": true
   },
-  "vars": {
-    "APP_ID": "b7b69981a7ce76e1fac5f64e1c5941ea"
-  },
   "durable_objects": {
     "bindings": [{ "name": "ROOMS", "class_name": "RoomCoordinator" }]
   },


### PR DESCRIPTION
## What changed

- replace the Cloudflare Realtime SFU transport with direct WebRTC data channels
- use a bounded, hibernatable Durable Object only for SDP/ICE signaling
- form remembered peer-to-peer groups of up to five devices as a full mesh
- remove user-facing host/client roles and elect the internal coordinator automatically
- add group-code rotation, invitation URL cleanup, bounded reconnects, signaling limits, transfer backpressure, and message validation
- remove TURN, SFU, relay credentials, and all paid relay paths; Cloudflare STUN remains for direct-route discovery

## Why

The previous design made users reason about which device was the host and routed WebRTC through a paid SFU. Small subtitle-sync groups work better as direct peer meshes: any device can display subtitles or control playback, while the server handles only short-lived negotiation.

## Impact

Groups are remembered locally and reconnect when the app is reopened. Subtitle files and playback events travel directly between devices. Networks that cannot establish a direct WebRTC path remain intentionally unsupported because there is no TURN fallback.

The Durable Object uses Cloudflare's WebSocket Hibernation API, stores no membership or subtitle data, has no timers or outbound connections, and applies connection/message bounds to avoid runaway request or duration costs.

## Validation

- `pnpm typecheck`
- `pnpm build`
- `pnpm exec wrangler types --check`
- `pnpm exec wrangler deploy --dry-run`
- three-device WebSocket signaling test covering all three pair negotiations
- three isolated Chromium sessions, each observing two direct WebRTC peers
- group-code rotation and invitation URL cleanup browser checks
- two adversarial security/cost review passes with no remaining high-severity or runaway-cost finding
